### PR TITLE
Bumn Ruby to v3

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,7 +1,10 @@
 name: Go
 
 on:
-  - push
+  push:
+    paths-ignore:
+      - '.github/workflows/ruby.yml'
+      - 'ruby/**'
 
 jobs:
   build:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,7 +1,10 @@
 name: Gradle
 
 on:
-  - push
+  push:
+    paths-ignore:
+      - '.github/workflows/ruby.yml'
+      - 'ruby/**'
 
 jobs:
   build:

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -1,7 +1,10 @@
 name: NodeJS
 
 on:
-  - push
+  push:
+    paths-ignore:
+      - '.github/workflows/ruby.yml'
+      - 'ruby/**'
 
 jobs:
   build:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,7 +1,10 @@
 name: Python
 
 on:
-  - push
+  push:
+    paths-ignore:
+      - '.github/workflows/ruby.yml'
+      - 'ruby/**'
 
 jobs:
   build:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,7 +1,10 @@
 name: Ruby
 
 on:
-  - push
+  push:
+    paths:
+      - '.github/workflows/ruby.yml'
+      - 'ruby/**'
 
 jobs:
   build:
@@ -11,7 +14,7 @@ jobs:
       - name: Setup
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.3
           bundler-cache: true
       - name: Install dependencies
         run: bundle install --gemfile ruby/sinatra/Gemfile

--- a/ruby/sinatra/Gemfile
+++ b/ruby/sinatra/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org" do
   gem 'sinatra'
+  gem 'rackup'
+  gem 'puma'
   group :test do
     gem 'minitest'
     gem 'rack-test'

--- a/ruby/sinatra/Gemfile.lock
+++ b/ruby/sinatra/Gemfile.lock
@@ -1,0 +1,48 @@
+GEM
+  specs:
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    base64 (0.2.0)
+    logger (1.6.1)
+    minitest (5.25.1)
+    mustermann (3.0.3)
+      ruby2_keywords (~> 0.0.1)
+    nio4r (2.7.4)
+    puma (6.4.3)
+      nio4r (~> 2.0)
+    rack (3.1.8)
+    rack-protection (4.1.0)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.0.0)
+      rack (>= 3.0.0)
+    rack-test (2.1.0)
+      rack (>= 1.3)
+    rackup (2.2.1)
+      rack (>= 3)
+    ruby2_keywords (0.0.5)
+    sinatra (4.1.0)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.1.0)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
+    tilt (2.4.0)
+
+PLATFORMS
+  arm64-darwin-24
+  ruby
+
+DEPENDENCIES
+  minitest!
+  puma!
+  rack-test!
+  rackup!
+  sinatra!
+
+BUNDLED WITH
+   2.5.23

--- a/ruby/sinatra/extreme_startup.rb
+++ b/ruby/sinatra/extreme_startup.rb
@@ -1,5 +1,9 @@
 require 'sinatra'
 
+configure do
+  set :host_authorization, :permitted_hosts => nil
+end
+
 get '/' do
   query = params[:q]
   print query


### PR DESCRIPTION
- only run Ruby workflow for Ruby changes
- bump ruby version
  - bump gem versions
  - explicitly add gems required by sinatra
  - disable host protection