### PR TITLE
:arrow_up: bump dependencies

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.25.6
+          go-version: 1.26.2
       - run: |
           cd go/mux
           go test

--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
         with:
-          java-version: 21
+          java-version: 25
           distribution: temurin
           cache: gradle
       - run: ./gradlew build --no-daemon --max-workers 2 --scan

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,6 @@ subprojects {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
 }

--- a/go/mux/go.mod
+++ b/go/mux/go.mod
@@ -1,6 +1,6 @@
 module github.com/extremestartup
 
-go 1.25.1
+go 1.26.2
 
 require (
 	github.com/gorilla/mux v1.8.1


### PR DESCRIPTION
- Java 25
- Go 1.26
